### PR TITLE
Refactor: Rename and update Android Kotlin Multiplatform Library plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.kotlin.composeCompiler) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.kotlin.multiplatform) apply false
-    alias(libs.plugins.android.kotlin.multiplatform.library) apply false
+    alias(libs.plugins.android.kotlinMultiplatformLibrary) apply false
 }
 
 tasks.register("clean", Delete::class) {

--- a/core/api/build.gradle.kts
+++ b/core/api/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
-    alias(libs.plugins.android.kotlin.multiplatform.library)
+    alias(libs.plugins.android.kotlinMultiplatformLibrary)
 }
 
 kotlin {

--- a/core/db/build.gradle.kts
+++ b/core/db/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
-    alias(libs.plugins.android.kotlin.multiplatform.library)
+    alias(libs.plugins.android.kotlinMultiplatformLibrary)
     alias(libs.plugins.ksp)
 }
 

--- a/core/player/build.gradle.kts
+++ b/core/player/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
-    alias(libs.plugins.android.kotlin.multiplatform.library)
+    alias(libs.plugins.android.kotlinMultiplatformLibrary)
 }
 
 kotlin {

--- a/core/properties/build.gradle.kts
+++ b/core/properties/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
-    alias(libs.plugins.android.kotlin.multiplatform.library)
+    alias(libs.plugins.android.kotlinMultiplatformLibrary)
 }
 
 kotlin {

--- a/core/utils/build.gradle.kts
+++ b/core/utils/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
-    alias(libs.plugins.android.kotlin.multiplatform.library)
+    alias(libs.plugins.android.kotlinMultiplatformLibrary)
 }
 
 kotlin {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -83,10 +83,10 @@ lifecycle = [
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-plugin" }
 android-library = { id = "com.android.library", version.ref = "android-plugin" }
+android-kotlinMultiplatformLibrary = { id = "com.android.kotlin.multiplatform.library", version.ref = "android-plugin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlin-composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
 ksp = { id = "com.google.devtools.ksp", version = "2.1.10-1.0.31" }
-kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
-android-kotlin-multiplatform-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "android-plugin" }

--- a/shared/favorites/build.gradle.kts
+++ b/shared/favorites/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
-    alias(libs.plugins.android.kotlin.multiplatform.library)
+    alias(libs.plugins.android.kotlinMultiplatformLibrary)
 }
 
 kotlin {

--- a/shared/queue/build.gradle.kts
+++ b/shared/queue/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
-    alias(libs.plugins.android.kotlin.multiplatform.library)
+    alias(libs.plugins.android.kotlinMultiplatformLibrary)
 }
 
 kotlin {

--- a/shared/song/random/build.gradle.kts
+++ b/shared/song/random/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
-    alias(libs.plugins.android.kotlin.multiplatform.library)
+    alias(libs.plugins.android.kotlinMultiplatformLibrary)
 }
 
 kotlin {


### PR DESCRIPTION
Renamed the `android.kotlin.multiplatform.library` plugin alias to `android.kotlinMultiplatformLibrary` for consistency and updated its usage across multiple `build.gradle.kts` files.