### PR TITLE
Refactor: Add scroll behavior to top app bars

### DIFF
--- a/feature/player/queue/src/commonMain/kotlin/ru/stersh/youamp/feature/player/queue/ui/PlayerQueueScreen.kt
+++ b/feature/player/queue/src/commonMain/kotlin/ru/stersh/youamp/feature/player/queue/ui/PlayerQueueScreen.kt
@@ -21,12 +21,14 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -79,6 +81,7 @@ private fun PlayerQueueScreen(
     onMoveSong: (from: Int, to: Int) -> Unit,
     onBackClick: () -> Unit,
 ) {
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     Scaffold(
         topBar = {
             LargeTopAppBar(
@@ -87,9 +90,11 @@ private fun PlayerQueueScreen(
                 },
                 navigationIcon = {
                     BackNavigationButton(onClick = onBackClick)
-                }
+                },
+                scrollBehavior = scrollBehavior
             )
-        }
+        },
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
     ) { padding ->
         if (state.progress) {
             Progress(

--- a/feature/server/list/src/commonMain/kotlin/ru/stersh/youamp/feature/server/list/ui/ServerListScreen.kt
+++ b/feature/server/list/src/commonMain/kotlin/ru/stersh/youamp/feature/server/list/ui/ServerListScreen.kt
@@ -100,7 +100,8 @@ private fun ServerListScreen(
                 },
                 title = {
                     Text(text = stringResource(Res.string.server_screen_title))
-                }
+                },
+                scrollBehavior = scrollBehavior
             )
         },
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)


### PR DESCRIPTION
- Added `enterAlwaysScrollBehavior` to `PlayerQueueScreen`'s top app bar.
- Added `nestedScroll` modifier to `PlayerQueueScreen` and `ServerListScreen`'s scaffold.
- Added `scrollBehavior` to `ServerListScreen`'s top app bar.

Closes #410