### PR TITLE
fix: French translations with single quote

### DIFF
--- a/core/ui/src/commonMain/composeResources/values-fr-rFR/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-fr-rFR/strings.xml
@@ -5,10 +5,10 @@
     <string name="play_all_title">Tout lire</string>
     <string name="placeholder_image_description">Image de substitution</string>
     <string name="error_button_title">Réessayer</string>
-    <string name="error_message">Réessayez. Si l\'erreur se produit plusieurs fois, contactez le développeur.</string>
+    <string name="error_message">Réessayez. Si l’erreur se produit plusieurs fois, contactez le développeur.</string>
     <string name="error_title">Oups, une erreur est arrivée</string>
-    <string name="empty_state_title">Il n\'y a rien encore ici…</string>
+    <string name="empty_state_title">Il n’y a rien encore ici…</string>
     <string name="user_avatar_title">Avatar de l’utilisateur</string>
-    <string name="dislike_title">Je n\'aime pas</string>
+    <string name="dislike_title">Je n’aime pas</string>
     <string name="like_title">J’aime</string>
 </resources>

--- a/feature/about/src/commonMain/composeResources/values-fr-rFR/strings.xml
+++ b/feature/about/src/commonMain/composeResources/values-fr-rFR/strings.xml
@@ -5,7 +5,7 @@
     <string name="f_droid_icon_description">Icône F-Droid</string>
     <string name="f_droid_subtitle">Vérifier les mises à jour</string>
     <string name="crowdin_icon_description">Icône Crowdin</string>
-    <string name="crowdin_subtitle">Aide à traduire</string>
+    <string name="crowdin_subtitle">Aider à traduire</string>
     <string name="about_title">A propos</string>
-    <string name="app_icon_description">Icône de l\'application</string>
+    <string name="app_icon_description">Icône de l’application</string>
 </resources>

--- a/feature/player/queue/src/commonMain/composeResources/values-fr-rFR/strings.xml
+++ b/feature/player/queue/src/commonMain/composeResources/values-fr-rFR/strings.xml
@@ -2,5 +2,5 @@
 <resources>
     <string name="play_queue_title">Jouer liste de lecture</string>
     <string name="play_song_title">Lire le titre</string>
-    <string name="remove_from_queue_title">Retirer de la file d\'attente</string>
+    <string name="remove_from_queue_title">Retirer de la file d’attente</string>
 </resources>

--- a/feature/search/src/commonMain/composeResources/values-fr-rFR/strings.xml
+++ b/feature/search/src/commonMain/composeResources/values-fr-rFR/strings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="play_title">Lire</string>
-    <string name="add_to_queue_title">Ajouter à la file d\'attente</string>
-    <string name="artist_info_title">Informations sur l\'artiste</string>
-    <string name="album_info_title">Infos sur l\'album</string>
+    <string name="add_to_queue_title">Ajouter à la file d’attente</string>
+    <string name="artist_info_title">Informations sur l’artiste</string>
+    <string name="album_info_title">Infos sur l’album</string>
     <string name="songs_title">Chansons</string>
-    <string name="load_more_title">Charger plus d\'éléments</string>
+    <string name="load_more_title">Charger plus d’éléments</string>
     <string name="albums_title">Albums</string>
     <string name="artists_title">Artistes</string>
     <string name="close_search_title">Fermer la recherche</string>

--- a/feature/server/create/src/commonMain/composeResources/values-fr-rFR/strings.xml
+++ b/feature/server/create/src/commonMain/composeResources/values-fr-rFR/strings.xml
@@ -8,14 +8,14 @@
     <string name="server_address_title">Adresse</string>
     <string name="server_username_title">Nom d’utilisateur</string>
     <string name="server_password_title">Mot de passe</string>
-    <string name="server_use_legacy_auth_title">Utiliser l\'ancienne authentification</string>
+    <string name="server_use_legacy_auth_title">Utiliser l’ancienne authentification</string>
     <string name="server_test_title">Test</string>
     <string name="server_add_action_title">Ajouter</string>
     <string name="server_save_action_title">Sauvegarder</string>
     <string name="hide_password_description">Masquer le mot de passe</string>
     <string name="show_password_description">Afficher le mot de passe</string>
     <string name="server_icon_description">Icône du serveur</string>
-    <string name="user_icon_description">Image de l\'utilisateur</string>
-    <string name="use_legacy_auth_subtitle">Certains serveurs ne prennent pas en charge l\'authentification avec un sel. Si vous avez des problèmes de connexion, activez cette option</string>
+    <string name="user_icon_description">Image de l’utilisateur</string>
+    <string name="use_legacy_auth_subtitle">Certains serveurs ne prennent pas en charge l’authentification avec un sel. Si vous avez des problèmes de connexion, activez cette option</string>
     <string name="additional_settings_title">Paramètres supplémentaires</string>
 </resources>

--- a/feature/settings/src/commonMain/composeResources/values-fr-rFR/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values-fr-rFR/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="about_title">A propos</string>
-    <string name="about_subtitle">Infos sur l\'application, liens vers les commentaires</string>
+    <string name="about_subtitle">Infos sur l’application, liens vers les commentaires</string>
     <string name="servers_title">Serveurs</string>
     <string name="servers_subtitle">Gérer vos serveurs Subsonic</string>
     <string name="about_icon_description">Icône À propos</string>

--- a/feature/song/info/src/commonMain/composeResources/values-fr-rFR/strings.xml
+++ b/feature/song/info/src/commonMain/composeResources/values-fr-rFR/strings.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="play_title">Lire</string>
-    <string name="play_next_in_queue_title">Jouer le suivant dans la file d\'attente</string>
-    <string name="go_to_album_title">Aller à l\'album</string>
-    <string name="go_to_artist_title">Aller à l\'artiste</string>
+    <string name="play_next_in_queue_title">Jouer le suivant dans la file d’attente</string>
+    <string name="go_to_album_title">Aller à l’album</string>
+    <string name="go_to_artist_title">Aller à l’artiste</string>
     <string name="add_to_favorites">Ajouter aux favoris</string>
     <string name="remove_from_favorites">Supprimer des favoris</string>
 </resources>


### PR DESCRIPTION
Single quotes were shown with the escape character (as-is: `\'`). But more importantly, single quotes are not used for that, instead we use the `’` character.