### PR TITLE
feat: redesign content

### DIFF
--- a/core/player/src/androidMain/kotlin/ru/stersh/youamp/core/player/Di.kt
+++ b/core/player/src/androidMain/kotlin/ru/stersh/youamp/core/player/Di.kt
@@ -10,32 +10,42 @@ import okhttp3.OkHttpClient
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
-actual val playerCoreModule: Module = module {
-    single<androidx.media3.common.Player> {
-        val okHttpClient = OkHttpClient
-            .Builder()
-            .build()
+actual val playerCoreModule: Module =
+    module {
+        single<androidx.media3.common.Player> {
+            val okHttpClient =
+                OkHttpClient
+                    .Builder()
+                    .build()
 
-        val okHttpDataSource = OkHttpDataSource
-            .Factory(okHttpClient)
-            .setDefaultRequestProperties(emptyMap())
+            val okHttpDataSource =
+                OkHttpDataSource
+                    .Factory(okHttpClient)
+                    .setDefaultRequestProperties(emptyMap())
 
-        val resolver = ResolvingDataSource.Resolver {
-            it
-                .buildUpon()
-                .setHttpRequestHeaders(emptyMap())
+            val resolver =
+                ResolvingDataSource.Resolver {
+                    it
+                        .buildUpon()
+                        .setHttpRequestHeaders(emptyMap())
+                        .build()
+                }
+
+            val resolvingDataSource = ResolvingDataSource.Factory(
+                okHttpDataSource,
+                resolver
+            )
+
+            ExoPlayer
+                .Builder(get())
+                .setLooper(PlayerThread.looper)
+                .setMediaSourceFactory(DefaultMediaSourceFactory(resolvingDataSource))
+                .setAudioAttributes(
+                    AudioAttributes.DEFAULT,
+                    true
+                )
+                .setWakeMode(C.WAKE_MODE_NETWORK)
                 .build()
         }
-
-        val resolvingDataSource = ResolvingDataSource.Factory(okHttpDataSource, resolver)
-
-        ExoPlayer
-            .Builder(get())
-            .setLooper(PlayerThread.looper)
-            .setMediaSourceFactory(DefaultMediaSourceFactory(resolvingDataSource))
-            .setAudioAttributes(AudioAttributes.DEFAULT, true)
-            .setWakeMode(C.WAKE_MODE_NETWORK)
-            .build()
+        single<Player> { AndroidPlayer(get()) }
     }
-    single<Player> { AndroidPlayer(get()) }
-}

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -22,6 +22,7 @@ kotlin {
             api(libs.compose.material3.windowSizeClass)
             implementation(compose.components.resources)
             implementation(libs.coil.compose)
+            implementation(libs.kotlinx.collectionsImmutable)
         }
     }
 }

--- a/core/ui/src/commonMain/kotlin/ru/stersh/youamp/core/ui/Album.kt
+++ b/core/ui/src/commonMain/kotlin/ru/stersh/youamp/core/ui/Album.kt
@@ -1,18 +1,23 @@
 package ru.stersh.youamp.core.ui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Album
-import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.Layout
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
@@ -22,107 +27,55 @@ fun AlbumItem(
     onClick: () -> Unit,
     artist: String? = null,
     artworkUrl: String? = null,
-    playButton: @Composable () -> Unit = {},
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
-    ElevatedCard(
-        shape = MaterialTheme.shapes.large,
-        onClick = onClick,
-        modifier = modifier
+    Column(
+        modifier = modifier.requiredWidth(AlbumItemDefaults.Width),
     ) {
-        AlbumLayout(
-            title = {
+        Card(
+            onClick = onClick,
+        ) {
+            Artwork(
+                artworkUrl = artworkUrl,
+                shape = MaterialTheme.shapes.medium,
+                placeholder = Icons.Rounded.Album,
+                modifier = Modifier.aspectRatio(1f),
+            )
+        }
+
+        Column(
+            modifier = Modifier.padding(top = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Text(
+                text = title,
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Left,
+                minLines = 1,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                color = MaterialTheme.colorScheme.onBackground,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+
+            if (artist != null) {
                 Text(
-                    text = title,
+                    text = artist,
                     modifier = Modifier.fillMaxWidth(),
                     textAlign = TextAlign.Left,
                     minLines = 1,
                     maxLines = 1,
-                    style = MaterialTheme.typography.labelLarge
+                    overflow = TextOverflow.Ellipsis,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.bodyMedium,
                 )
-            },
-            artist = {
-                if (artist != null) {
-                    Text(
-                        text = artist,
-                        modifier = Modifier.fillMaxWidth(),
-                        textAlign = TextAlign.Left,
-                        minLines = 1,
-                        maxLines = 1,
-                        style = MaterialTheme.typography.bodyMedium
-                    )
-                }
-            },
-            artwork = {
-                Artwork(
-                    artworkUrl = artworkUrl,
-                    placeholder = Icons.Rounded.Album
-                )
-            },
-            playButton = playButton
-        )
-    }
-}
-
-@Composable
-private fun AlbumLayout(
-    title: @Composable () -> Unit,
-    artist: @Composable () -> Unit,
-    artwork: @Composable () -> Unit,
-    playButton: @Composable () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val density = LocalDensity.current
-    val contentPadding = 12.dp.roundToPx(density)
-    val titleTopPadding = 4.dp.roundToPx(density)
-    Layout(
-        contents = listOf(
-            title,
-            artist,
-            artwork,
-            playButton
-        ),
-        modifier = modifier
-    ) { measurables, constraints ->
-
-        val titlePlaceable = measurables[0]
-            .first()
-            .measure(constraints)
-        val artistPlaceable = measurables
-            .getOrNull(1)
-            ?.firstOrNull()
-            ?.measure(constraints)
-        val artworkPlaceable = measurables[2]
-            .first()
-            .measure(Constraints.fixed(constraints.maxWidth, constraints.maxWidth))
-        val playButtonPlaceable = measurables
-            .getOrNull(3)
-            ?.firstOrNull()
-            ?.measure(constraints)
-
-        val maxHeight = titlePlaceable.height + (artistPlaceable?.height ?: 0) +
-                artworkPlaceable.height + ((playButtonPlaceable?.height ?: 0) / 2) + titleTopPadding + contentPadding
-
-        layout(artworkPlaceable.width, maxHeight) {
-            artworkPlaceable.placeRelative(0, 0)
-            playButtonPlaceable?.placeRelative(
-                (artworkPlaceable.width / 2) - (playButtonPlaceable.width / 2),
-                artworkPlaceable.height - (playButtonPlaceable.height / 2)
-            )
-            val titleY = if (playButtonPlaceable != null) {
-                artworkPlaceable.height + titleTopPadding + (playButtonPlaceable.height / 2)
-            } else {
-                artworkPlaceable.height + titleTopPadding
             }
-            titlePlaceable.placeRelative(contentPadding, titleY)
-            artistPlaceable?.placeRelative(contentPadding, titleY + artistPlaceable.height)
         }
     }
 }
 
 @Stable
 object AlbumItemDefaults {
-
     @Stable
     val Width = 160.dp
 }
@@ -130,17 +83,19 @@ object AlbumItemDefaults {
 @Composable
 @Preview
 private fun AlbumItemPreview() {
-    MaterialTheme {
-        AlbumItem(
-            title = "Album",
-            artist = "artist",
-            playButton = {
-                PlayButtonOutlined(
-                    isPlaying = false,
-                    onClick = {},
-                )
-            },
-            onClick = {}
-        )
+    YouampPlayerTheme {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(24.dp),
+            modifier = Modifier.background(MaterialTheme.colorScheme.background),
+        ) {
+            AlbumItem(
+                title = "Album",
+                artist = "artist",
+                onClick = {},
+            )
+            SkeletonLayout {
+                AlbumSkeleton()
+            }
+        }
     }
 }

--- a/core/ui/src/commonMain/kotlin/ru/stersh/youamp/core/ui/Artist.kt
+++ b/core/ui/src/commonMain/kotlin/ru/stersh/youamp/core/ui/Artist.kt
@@ -2,13 +2,13 @@ package ru.stersh.youamp.core.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material3.MaterialTheme
@@ -17,222 +17,85 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.Layout
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
-
 @Composable
 fun ArtistItem(
     name: String,
     onClick: () -> Unit,
     artworkUrl: String? = null,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
-    ArtistLayout(
-        name = {
-            ArtistTitle(name)
-        },
-        artwork = {
-            ArtistArtwork(artworkUrl)
-        },
-        modifier = modifier
-            .clip(ArtistItemDefaults.Shape)
-            .clickable(onClick = onClick)
-            .requiredWidth(ArtistItemDefaults.Width)
-    )
-}
-
-@Composable
-fun ArtistItem(
-    name: String,
-    playButton: @Composable () -> Unit,
-    onClick: () -> Unit,
-    artworkUrl: String? = null,
-    modifier: Modifier = Modifier
-) {
-    ArtistLayout(
-        name = {
-            ArtistTitle(name)
-        },
-        artwork = {
-            ArtistArtwork(artworkUrl)
-        },
-        playButton = playButton,
-        modifier = modifier
-            .clip(ArtistItemDefaults.Shape)
-            .clickable(onClick = onClick)
-    )
+    Column(
+        modifier =
+            modifier
+                .requiredWidth(ArtistItemDefaults.Width),
+    ) {
+        ArtistArtwork(
+            artworkUrl,
+            modifier =
+                Modifier
+                    .clip(CircleShape)
+                    .clickable(onClick = onClick),
+        )
+        ArtistTitle(
+            name = name,
+            modifier = Modifier.padding(top = 8.dp),
+        )
+    }
 }
 
 @Composable
 private fun ArtistTitle(
     name: String,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Text(
         text = name,
         textAlign = TextAlign.Center,
-        minLines = 2,
+        minLines = 1,
         maxLines = 2,
         color = MaterialTheme.colorScheme.onBackground,
-        style = MaterialTheme.typography.titleMedium,
-        modifier = modifier.fillMaxWidth()
+        style = MaterialTheme.typography.bodyLarge,
+        modifier = modifier.fillMaxWidth(),
     )
 }
 
 @Composable
 private fun ArtistArtwork(
     artworkUrl: String?,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     CircleArtwork(
         artworkUrl = artworkUrl,
         placeholder = Icons.Rounded.Person,
-        modifier = modifier
+        modifier = modifier,
     )
 }
-
-@Composable
-
-private fun PlayButtonBackground(modifier: Modifier = Modifier) {
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .aspectRatio(1f)
-            .background(
-                brush = Brush.verticalGradient(
-                    colorStops = arrayOf(
-                        0.2f to Color.Transparent,
-                        0.7f to MaterialTheme.colorScheme.surfaceContainerLow
-                    )
-                ),
-                shape = CircleShape
-            )
-    )
-}
-
-@Composable
-private fun ArtistLayout(
-    name: @Composable () -> Unit,
-    artwork: @Composable () -> Unit,
-    playButton: @Composable () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val density = LocalDensity.current
-    val titleTopPadding = 8.dp.roundToPx(density)
-    val contentPadding = 12.dp.roundToPx(density)
-    val playButtonPadding = 8.dp.roundToPx(density)
-    Layout(
-        contents = listOf(
-            name,
-            artwork,
-            playButton,
-            {
-                PlayButtonBackground()
-            }
-        ),
-        modifier = modifier
-    ) { measurables, constraints ->
-
-        val artworkConstraints = Constraints.fixed(constraints.maxWidth, constraints.maxWidth)
-        val titlePlaceable = measurables[0]
-            .first()
-            .measure(constraints)
-        val artworkPlaceable = measurables[1]
-            .first()
-            .measure(artworkConstraints)
-        val playButtonPlaceable = measurables[2]
-            .first()
-            .measure(constraints.copy(minWidth = 0, minHeight = 0))
-        val playButtonBackgroundPlaceable = measurables[3]
-            .first()
-            .measure(artworkConstraints)
-
-        val maxHeight = titlePlaceable.height + artworkPlaceable.height + titleTopPadding + contentPadding
-
-        layout(artworkPlaceable.width, maxHeight) {
-            artworkPlaceable.placeRelative(0, 0)
-            playButtonBackgroundPlaceable.placeRelative(0, 0)
-            playButtonPlaceable.placeRelative(
-                (artworkPlaceable.width / 2) - (playButtonPlaceable.width / 2),
-                artworkPlaceable.height - playButtonPlaceable.height - playButtonPadding
-            )
-            titlePlaceable.placeRelative(0, artworkPlaceable.height + titleTopPadding)
-        }
-    }
-}
-
-@Composable
-private fun ArtistLayout(
-    name: @Composable () -> Unit,
-    artwork: @Composable () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val density = LocalDensity.current
-    val titleTopPadding = 8.dp.roundToPx(density)
-    val contentPadding = 12.dp.roundToPx(density)
-    Layout(
-        contents = listOf(
-            name,
-            artwork
-        ),
-        modifier = modifier
-    ) { measurables, constraints ->
-
-        val titlePlaceable = measurables[0]
-            .first()
-            .measure(constraints)
-        val artworkPlaceable = measurables[1]
-            .first()
-            .measure(Constraints.fixed(constraints.maxWidth, constraints.maxWidth))
-
-        val maxHeight = titlePlaceable.height + artworkPlaceable.height + titleTopPadding + contentPadding
-
-        layout(artworkPlaceable.width, maxHeight) {
-            artworkPlaceable.placeRelative(0, 0)
-            titlePlaceable.placeRelative(0, artworkPlaceable.height + titleTopPadding)
-        }
-    }
-}
-
-@Stable
-private val ArtistShape = RoundedCornerShape(36.dp)
 
 @Stable
 object ArtistItemDefaults {
-
     @Stable
     val Width = 160.dp
-
-    @Stable
-    val Shape = RoundedCornerShape(36.dp)
 }
 
 @Composable
 @Preview
 private fun ArtistItemPreview() {
     MaterialTheme {
-        Column {
-            ArtistItem(
-                name = "Name",
-                onClick = {}
-            )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(24.dp),
+            modifier = Modifier.background(MaterialTheme.colorScheme.background),
+        ) {
             ArtistItem(
                 name = "Name",
                 onClick = {},
-                playButton = {
-                    PlayButtonOutlined(
-                        isPlaying = false,
-                        onClick = {}
-                    )
-                },
             )
+            SkeletonLayout {
+                ArtistSkeleton()
+            }
         }
     }
 }

--- a/core/ui/src/commonMain/kotlin/ru/stersh/youamp/core/ui/Playlist.kt
+++ b/core/ui/src/commonMain/kotlin/ru/stersh/youamp/core/ui/Playlist.kt
@@ -1,110 +1,65 @@
 package ru.stersh.youamp.core.ui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Album
+import androidx.compose.material.icons.rounded.MusicNote
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.Layout
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
-
 
 @Composable
 fun PlaylistItem(
     title: String,
     onClick: () -> Unit,
     artworkUrl: String? = null,
-    playButton: @Composable () -> Unit = {},
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
-    ElevatedCard(
-        shape = MaterialTheme.shapes.large,
-        onClick = onClick,
-        modifier = modifier
+    Column(
+        modifier = modifier.requiredWidth(PlaylistItemDefaults.Width),
     ) {
-        PlaylistLayout(
-            title = {
-                Text(
-                    text = title,
-                    modifier = Modifier.fillMaxWidth(),
-                    textAlign = TextAlign.Left,
-                    minLines = 1,
-                    maxLines = 1,
-                    style = MaterialTheme.typography.labelLarge
-                )
-            },
-            artwork = {
-                Artwork(
-                    artworkUrl = artworkUrl,
-                    placeholder = Icons.Rounded.Album
-                )
-            },
-            playButton = playButton
-        )
-    }
-}
-
-@Composable
-private fun PlaylistLayout(
-    title: @Composable () -> Unit,
-    artwork: @Composable () -> Unit,
-    playButton: @Composable () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val density = LocalDensity.current
-    val contentPadding = 12.dp.roundToPx(density)
-    val titleTopPadding = 4.dp.roundToPx(density)
-    Layout(
-        contents = listOf(
-            title,
-            artwork,
-            playButton
-        ),
-        modifier = modifier
-    ) { measurables, constraints ->
-
-        val titlePlaceable = measurables[0]
-            .first()
-            .measure(constraints)
-        val artworkPlaceable = measurables[1]
-            .first()
-            .measure(Constraints.fixed(constraints.maxWidth, constraints.maxWidth))
-        val playButtonPlaceable = measurables
-            .getOrNull(2)
-            ?.firstOrNull()
-            ?.measure(constraints)
-
-        val maxHeight =
-            titlePlaceable.height + artworkPlaceable.height + titleTopPadding + contentPadding + ((playButtonPlaceable?.height
-                ?: 0) / 2)
-
-        layout(artworkPlaceable.width, maxHeight) {
-            artworkPlaceable.placeRelative(0, 0)
-            playButtonPlaceable?.placeRelative(
-                (artworkPlaceable.width / 2) - (playButtonPlaceable.width / 2),
-                artworkPlaceable.height - (playButtonPlaceable.height / 2)
+        ElevatedCard(
+            onClick = onClick,
+        ) {
+            Artwork(
+                artworkUrl = artworkUrl,
+                shape = MaterialTheme.shapes.medium,
+                placeholder = Icons.Rounded.MusicNote,
+                modifier = Modifier.aspectRatio(1f),
             )
-            val titleY = if (playButtonPlaceable != null) {
-                artworkPlaceable.height + titleTopPadding + (playButtonPlaceable.height / 2)
-            } else {
-                artworkPlaceable.height + titleTopPadding
-            }
-            titlePlaceable.placeRelative(contentPadding, titleY)
         }
+
+        Text(
+            text = title,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp),
+            textAlign = TextAlign.Left,
+            minLines = 1,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            color = MaterialTheme.colorScheme.onBackground,
+            style = MaterialTheme.typography.bodyLarge,
+        )
     }
 }
 
 @Stable
 object PlaylistItemDefaults {
-
     @Stable
     val Width = 160.dp
 }
@@ -113,15 +68,17 @@ object PlaylistItemDefaults {
 @Preview
 private fun PlaylistItemPreview() {
     MaterialTheme {
-        PlaylistItem(
-            title = "Playlist",
-            playButton = {
-                PlayButtonOutlined(
-                    isPlaying = false,
-                    onClick = {},
-                )
-            },
-            onClick = {}
-        )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(24.dp),
+            modifier = Modifier.background(MaterialTheme.colorScheme.background),
+        ) {
+            PlaylistItem(
+                title = "Playlist",
+                onClick = {},
+            )
+            SkeletonLayout {
+                PlaylistSkeleton()
+            }
+        }
     }
 }

--- a/core/ui/src/commonMain/kotlin/ru/stersh/youamp/core/ui/Skeleton.kt
+++ b/core/ui/src/commonMain/kotlin/ru/stersh/youamp/core/ui/Skeleton.kt
@@ -7,15 +7,20 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
@@ -28,7 +33,6 @@ fun SkeletonLayout(
     modifier: Modifier = Modifier,
     content: @Composable SkeletonScope.() -> Unit
 ) {
-
     val infiniteTransition = rememberInfiniteTransition(label = "skeleton_animation")
     val alphaAnimation by infiniteTransition.animateFloat(
         initialValue = 1f,
@@ -48,7 +52,6 @@ fun SkeletonLayout(
 }
 
 object SkeletonScope {
-
     @Composable
     fun SkeletonItem(
         modifier: Modifier = Modifier,
@@ -58,11 +61,169 @@ object SkeletonScope {
         color: Color = MaterialTheme.colorScheme.surfaceContainerHigh
     ) {
         Box(
-            modifier = modifier.background(color = color, shape = shape)
+            modifier = modifier.background(
+                color = color,
+                shape = shape
+            ),
         )
     }
 }
 
+@Composable
+fun SkeletonScope.PlaylistSkeleton(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        SkeletonItem(
+            shape = MaterialTheme.shapes.medium,
+            modifier = Modifier.size(AlbumItemDefaults.Width),
+        )
+        SkeletonItem(
+            shape = MaterialTheme.shapes.medium,
+            modifier = Modifier.size(
+                120.dp,
+                24.dp
+            ),
+        )
+    }
+}
+
+@Composable
+fun SkeletonScope.AlbumSkeleton(
+    showArtist: Boolean = true,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        SkeletonItem(
+            shape = MaterialTheme.shapes.medium,
+            modifier = Modifier.size(AlbumItemDefaults.Width)
+        )
+        Column(
+            modifier = Modifier.padding(top = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp)
+        ) {
+            SkeletonItem(
+                shape = MaterialTheme.shapes.medium,
+                modifier = Modifier.size(
+                    120.dp,
+                    24.dp
+                )
+            )
+            if (showArtist) {
+                SkeletonItem(
+                    shape = MaterialTheme.shapes.medium,
+                    modifier = Modifier.size(
+                        80.dp,
+                        20.dp
+                    )
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun SkeletonScope.ArtistSkeleton(modifier: Modifier = Modifier) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier,
+    ) {
+        SkeletonItem(
+            shape = CircleShape,
+            modifier = Modifier.size(ArtistItemDefaults.Width),
+        )
+
+        SkeletonItem(
+            shape = MaterialTheme.shapes.medium,
+            modifier = Modifier.size(
+                120.dp,
+                24.dp
+            )
+        )
+    }
+}
+
+@Composable
+fun SkeletonScope.SongCardChunkSkeleton(modifier: Modifier = Modifier) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier,
+    ) {
+        SkeletonItem(
+            shape = SongCardDefaults.TopShape,
+            modifier = Modifier.size(
+                SongCardDefaults.Width,
+                64.dp
+            ),
+        )
+
+        SkeletonItem(
+            shape = SongCardDefaults.CenterShape,
+            modifier = Modifier.size(
+                SongCardDefaults.Width,
+                64.dp
+            ),
+        )
+
+        SkeletonItem(
+            shape = SongCardDefaults.BottomShape,
+            modifier = Modifier.size(
+                SongCardDefaults.Width,
+                64.dp
+            ),
+        )
+    }
+}
+
+@Composable
+fun SkeletonScope.SongSkeleton(modifier: Modifier = Modifier) {
+    ListItem(
+        headlineContent = {
+            SkeletonItem(
+                shape = MaterialTheme.shapes.medium,
+                modifier =
+                    Modifier.size(
+                        width = 180.dp,
+                        height = 24.dp,
+                    ),
+            )
+        },
+        supportingContent = {
+            SkeletonItem(
+                shape = MaterialTheme.shapes.medium,
+                modifier =
+                    Modifier
+                        .padding(2.dp)
+                        .size(
+                            width = 120.dp,
+                            height = 20.dp,
+                        ),
+            )
+        },
+        leadingContent = {
+            SkeletonItem(
+                modifier = Modifier.size(48.dp),
+            )
+        },
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun SkeletonScope.SectionSkeleton(modifier: Modifier = Modifier) {
+    SkeletonItem(
+        modifier =
+            Modifier
+                .padding(vertical = 28.dp)
+                .size(
+                    200.dp,
+                    32.dp
+                ),
+    )
+}
 
 @Composable
 @Preview
@@ -72,12 +233,20 @@ private fun SkeletonItemPreview() {
             SkeletonLayout {
                 Column {
                     SkeletonItem(
-                        modifier = Modifier
-                            .size(width = 60.dp, height = 48.dp)
+                        modifier =
+                            Modifier
+                                .size(
+                                    width = 60.dp,
+                                    height = 48.dp
+                                ),
                     )
                     SkeletonItem(
-                        modifier = Modifier
-                            .size(width = 130.dp, height = 20.dp)
+                        modifier =
+                            Modifier
+                                .size(
+                                    width = 130.dp,
+                                    height = 20.dp
+                                ),
                     )
                 }
             }

--- a/core/ui/src/commonMain/kotlin/ru/stersh/youamp/core/ui/Song.kt
+++ b/core/ui/src/commonMain/kotlin/ru/stersh/youamp/core/ui/Song.kt
@@ -1,12 +1,15 @@
 package ru.stersh.youamp.core.ui
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.MusicNote
-import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Card
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemColors
 import androidx.compose.material3.ListItemDefaults
@@ -23,23 +26,34 @@ fun SongCardItem(
     title: String,
     artist: String? = null,
     artworkUrl: String? = null,
-    playButton: @Composable () -> Unit = {},
+    type: SongCardType = SongCardType.Default,
     onClick: () -> Unit = {},
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
-    ElevatedCard(modifier = modifier) {
+    val shape = when (type) {
+        SongCardType.Default -> MaterialTheme.shapes.large
+        SongCardType.Top -> SongCardDefaults.TopShape
+        SongCardType.Center -> SongCardDefaults.CenterShape
+        SongCardType.Bottom -> SongCardDefaults.BottomShape
+    }
+    Card(
+        shape = shape,
+        modifier = modifier,
+    ) {
         SongItem(
             title = title,
             artist = artist,
             artworkUrl = artworkUrl,
             onClick = onClick,
-            modifier = Modifier
-                .fillMaxWidth(),
+            modifier =
+                Modifier
+                    .fillMaxWidth(),
             colors = songItemCardColors(),
-            trailingContent = playButton
         )
     }
 }
+
+enum class SongCardType { Default, Top, Center, Bottom }
 
 @Composable
 fun SongItem(
@@ -47,6 +61,8 @@ fun SongItem(
     artist: String? = null,
     artworkUrl: String? = null,
     onClick: () -> Unit = {},
+    isCurrent: Boolean = false,
+    isPlaying: Boolean = false,
     modifier: Modifier = Modifier,
     trailingContent: @Composable () -> Unit = {},
     colors: ListItemColors = ListItemDefaults.colors()
@@ -74,11 +90,47 @@ fun SongItem(
                 placeholder = Icons.Rounded.MusicNote,
                 modifier = Modifier.size(48.dp)
             )
+            if (isCurrent) {
+                SongPlayAnimation(
+                    isPlaying = isPlaying,
+                    modifier = Modifier
+                        .size(48.dp)
+                        .background(
+                            color = ArtworkMaskColor,
+                            shape = MaterialTheme.shapes.large
+                        )
+                        .padding(12.dp)
+                )
+            }
         },
         trailingContent = trailingContent,
         modifier = modifier.clickable(onClick = onClick),
         colors = colors
     )
+}
+
+@Stable
+object SongCardDefaults {
+    val TopShape = RoundedCornerShape(
+        topStart = 16.dp,
+        topEnd = 16.dp,
+        bottomStart = 4.dp,
+        bottomEnd = 4.dp
+    )
+    val BottomShape = RoundedCornerShape(
+        topStart = 4.dp,
+        topEnd = 4.dp,
+        bottomStart = 16.dp,
+        bottomEnd = 16.dp
+    )
+    val CenterShape = RoundedCornerShape(
+        topStart = 4.dp,
+        topEnd = 4.dp,
+        bottomStart = 4.dp,
+        bottomEnd = 4.dp
+    )
+
+    val Width = 336.dp
 }
 
 @Stable

--- a/core/ui/src/commonMain/kotlin/ru/stersh/youamp/core/ui/WindowSizeClass.kt
+++ b/core/ui/src/commonMain/kotlin/ru/stersh/youamp/core/ui/WindowSizeClass.kt
@@ -13,7 +13,14 @@ import androidx.compose.ui.unit.dp
 val DesktopWindowClassSize = WindowSizeClass.calculateFromSize(DpSize(1280.dp, 800.dp))
 
 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
-val MobileWindowClassSize = WindowSizeClass.calculateFromSize(DpSize(1080.dp, 2400.dp))
+val MobileWindowClassSize = WindowSizeClass.calculateFromSize(
+    size = DpSize(
+        1080.dp,
+        2400.dp
+    ),
+    supportedWidthSizeClasses = setOf(WindowWidthSizeClass.Compact),
+    supportedHeightSizeClasses = setOf(WindowHeightSizeClass.Medium)
+)
 
 val LocalWindowSizeClass = compositionLocalOf<WindowSizeClass> {
     MobileWindowClassSize

--- a/feature/album/favorites/src/commonMain/kotlin/ru/stersh/youamp/feature/album/favorites/ui/FavoriteAlbumsScreen.kt
+++ b/feature/album/favorites/src/commonMain/kotlin/ru/stersh/youamp/feature/album/favorites/ui/FavoriteAlbumsScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -11,15 +12,16 @@ import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -29,6 +31,7 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
 import ru.stersh.youamp.core.ui.AlbumItem
 import ru.stersh.youamp.core.ui.AlbumItemDefaults
+import ru.stersh.youamp.core.ui.AlbumSkeleton
 import ru.stersh.youamp.core.ui.BackNavigationButton
 import ru.stersh.youamp.core.ui.EmptyLayout
 import ru.stersh.youamp.core.ui.ErrorLayout
@@ -158,20 +161,78 @@ private fun FavoriteAlbumsScreen(
 
 @Composable
 private fun Progress() {
-    SkeletonLayout {
-        repeat(10) {
-            ListItem(
-                headlineContent = {
-                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                        SkeletonItem(modifier = Modifier.size(width = 130.dp, height = 16.dp))
-                        SkeletonItem(modifier = Modifier.size(width = 200.dp, height = 16.dp))
-                    }
-                },
-                leadingContent = {
-                    SkeletonItem(modifier = Modifier.size(48.dp))
-                }
-            )
+    SkeletonLayout(modifier = Modifier.fillMaxSize()) {
+        LazyVerticalGrid(
+            columns = if (isCompactWidth) {
+                GridCells.Fixed(2)
+            } else {
+                GridCells.Adaptive(AlbumItemDefaults.Width)
+            },
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            item(
+                span = { GridItemSpan(maxLineSpan) }
+            ) {
+                HeaderLayout(
+                    title = {
+                        Column(
+                            modifier = Modifier.singleHeader(),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            SkeletonItem(
+                                modifier = Modifier
+                                    .size(
+                                        400.dp,
+                                        32.dp
+                                    )
+                            )
+                            SkeletonItem(
+                                modifier = Modifier
+                                    .size(
+                                        200.dp,
+                                        32.dp
+                                    )
+                            )
+                        }
+                    },
+                    actions = {
+                        SkeletonItem(
+                            shape = CircleShape,
+                            modifier = Modifier.size(64.dp)
+                        )
+                        SkeletonItem(
+                            shape = CircleShape,
+                            modifier = Modifier.size(64.dp)
+                        )
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 28.dp)
+                )
+            }
+            repeat(10) {
+                item { AlbumSkeleton() }
+            }
         }
+    }
+}
+
+@Preview
+@Composable
+private fun FavoriteAlbumsScreenProgressPreview() {
+    MaterialTheme {
+        FavoriteAlbumsScreen(
+            state = StateUi(),
+            onPlayAll = {},
+            onPlayShuffled = {},
+            onRetry = {},
+            onRefresh = {},
+            onAlbumClick = {},
+            onBackClick = {}
+        )
     }
 }
 

--- a/feature/album/info/src/commonMain/kotlin/ru/stersh/youamp/feature/album/info/ui/AlbumInfoScreen.kt
+++ b/feature/album/info/src/commonMain/kotlin/ru/stersh/youamp/feature/album/info/ui/AlbumInfoScreen.kt
@@ -1,7 +1,6 @@
 package ru.stersh.youamp.feature.album.info.ui
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -19,7 +18,6 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -37,10 +35,11 @@ import ru.stersh.youamp.core.ui.BackNavigationButton
 import ru.stersh.youamp.core.ui.ErrorLayout
 import ru.stersh.youamp.core.ui.FavoriteButton
 import ru.stersh.youamp.core.ui.HeaderLayout
-import ru.stersh.youamp.core.ui.LocalWindowSizeClass
 import ru.stersh.youamp.core.ui.PlayAllButton
 import ru.stersh.youamp.core.ui.PlayShuffledButton
 import ru.stersh.youamp.core.ui.SkeletonLayout
+import ru.stersh.youamp.core.ui.SongSkeleton
+import ru.stersh.youamp.core.ui.isCompactWidth
 
 
 @Composable
@@ -98,7 +97,7 @@ private fun AlbumInfoScreen(
             }
 
             state.content != null -> {
-                ContentState(
+                Content(
                     state = state.content,
                     onPlayAll = onPlayAll,
                     onPlayShuffled = onPlayShuffled,
@@ -124,25 +123,36 @@ private fun Progress(padding: PaddingValues) {
                     )
                 },
                 title = {
-                    if (LocalWindowSizeClass.current.widthSizeClass == WindowWidthSizeClass.Compact) {
+                    if (isCompactWidth) {
                         Box(modifier = Modifier.fillMaxWidth()) {
                             SkeletonItem(
-                                modifier = Modifier.size(280.dp, 32.dp)
+                                modifier = Modifier
+                                    .size(
+                                        280.dp,
+                                        32.dp
+                                    )
                                     .fillMaxWidth()
                                     .align(Alignment.Center)
                             )
                         }
                     } else {
                         SkeletonItem(
-                            modifier = Modifier.size(300.dp, 48.dp)
+                            modifier = Modifier.size(
+                                300.dp,
+                                48.dp
+                            )
                         )
                     }
                 },
                 subtitle = {
-                    if (LocalWindowSizeClass.current.widthSizeClass == WindowWidthSizeClass.Compact) {
+                    if (isCompactWidth) {
                         Box(modifier = Modifier.fillMaxWidth()) {
                             SkeletonItem(
-                                modifier = Modifier.size(220.dp, 24.dp)
+                                modifier = Modifier
+                                    .size(
+                                        220.dp,
+                                        24.dp
+                                    )
                                     .fillMaxWidth()
                                     .padding(top = 4.dp)
                                     .align(Alignment.Center)
@@ -151,46 +161,31 @@ private fun Progress(padding: PaddingValues) {
                     } else {
                         SkeletonItem(
                             modifier = Modifier
-                                .size(220.dp, 24.dp)
+                                .size(
+                                    220.dp,
+                                    24.dp
+                                )
                                 .padding(top = 4.dp)
                         )
                     }
                 },
                 actions = {
-                    repeat(2) {
+                    repeat(3) {
                         SkeletonItem(
-                            modifier = Modifier.size(64.dp)
+                            modifier = Modifier
+                                .size(64.dp)
                                 .clip(CircleShape)
                         )
                     }
                 }
             )
             LazyColumn(
-                userScrollEnabled = false
+                userScrollEnabled = false,
+                modifier = Modifier.padding(top = 28.dp)
             ) {
                 repeat(5) {
                     item {
-                        ListItem(
-                            headlineContent = {
-                                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                                    SkeletonItem(
-                                        modifier = Modifier.size(
-                                            width = 130.dp,
-                                            height = 16.dp
-                                        )
-                                    )
-                                    SkeletonItem(
-                                        modifier = Modifier.size(
-                                            width = 200.dp,
-                                            height = 16.dp
-                                        )
-                                    )
-                                }
-                            },
-                            leadingContent = {
-                                SkeletonItem(modifier = Modifier.size(48.dp))
-                            }
-                        )
+                        SongSkeleton()
                     }
                 }
             }
@@ -199,7 +194,7 @@ private fun Progress(padding: PaddingValues) {
 }
 
 @Composable
-private fun ContentState(
+private fun Content(
     state: AlbumInfoUi,
     onPlayAll: () -> Unit,
     onPlayShuffled: () -> Unit,
@@ -313,6 +308,20 @@ private fun AlbumSongItem(
             Text(text = song.duration)
         },
         modifier = Modifier.clickable(onClick = onClick)
+    )
+}
+
+@Preview
+@Composable
+private fun AlbumInfoScreenProgressPreview() {
+    AlbumInfoScreen(
+        state = AlbumInfoStateUi(),
+        onPlayAll = {},
+        onPlayShuffled = {},
+        onFavoriteChange = {},
+        onPlaySong = {},
+        onRetry = {},
+        onBackClick = {}
     )
 }
 

--- a/feature/album/list/src/commonMain/kotlin/ru/stersh/youamp/feature/album/list/ui/AlbumsScreen.kt
+++ b/feature/album/list/src/commonMain/kotlin/ru/stersh/youamp/feature/album/list/ui/AlbumsScreen.kt
@@ -3,7 +3,6 @@ package ru.stersh.youamp.feature.album.list.ui
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyGridState
@@ -29,6 +28,7 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
 import ru.stersh.youamp.core.ui.AlbumItem
 import ru.stersh.youamp.core.ui.AlbumItemDefaults
+import ru.stersh.youamp.core.ui.AlbumSkeleton
 import ru.stersh.youamp.core.ui.BackNavigationButton
 import ru.stersh.youamp.core.ui.EmptyLayout
 import ru.stersh.youamp.core.ui.ErrorLayout
@@ -160,20 +160,38 @@ private fun Content(
 private fun Progress() {
     SkeletonLayout {
         LazyVerticalGrid(
-            columns = GridCells.Adaptive(160.dp),
+            columns = if (isCompactWidth) {
+                GridCells.Fixed(2)
+            } else {
+                GridCells.Adaptive(AlbumItemDefaults.Width)
+            },
             contentPadding = PaddingValues(16.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.fillMaxSize()
         ) {
             items(
                 key = { it },
                 items = (0..10).toList()
             ) {
-                SkeletonItem(
-                    modifier = Modifier.height(240.dp)
-                )
+                AlbumSkeleton()
             }
         }
+    }
+}
+
+@Composable
+@Preview
+private fun AlbumsScreenProgressPreview() {
+    YouampPlayerTheme {
+        AlbumsScreen(
+            state = AlbumsStateUi(),
+            onRefresh = {},
+            onRetry = {},
+            onBottomReached = {},
+            onAlbumClick = {},
+            onBackClick = {}
+        )
     }
 }
 

--- a/feature/artist/favorites/src/commonMain/kotlin/ru/stersh/youamp/feature/artist/favorites/ui/FavoriteArtistScreen.kt
+++ b/feature/artist/favorites/src/commonMain/kotlin/ru/stersh/youamp/feature/artist/favorites/ui/FavoriteArtistScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -11,15 +12,16 @@ import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -29,6 +31,7 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
 import ru.stersh.youamp.core.ui.AlbumItemDefaults
 import ru.stersh.youamp.core.ui.ArtistItem
+import ru.stersh.youamp.core.ui.ArtistSkeleton
 import ru.stersh.youamp.core.ui.BackNavigationButton
 import ru.stersh.youamp.core.ui.EmptyLayout
 import ru.stersh.youamp.core.ui.ErrorLayout
@@ -141,11 +144,11 @@ private fun FavoriteArtistsScreen(
                             items = state.data.artists,
                             contentType = { "artist" },
                             key = { "artist_${it.id}" }
-                        ) { album ->
+                        ) { artist ->
                             ArtistItem(
-                                name = album.name,
-                                onClick = { onArtistClick(album.id) },
-                                artworkUrl = album.artworkUrl
+                                name = artist.name,
+                                onClick = { onArtistClick(artist.id) },
+                                artworkUrl = artist.artworkUrl
                             )
                         }
                     }
@@ -157,20 +160,78 @@ private fun FavoriteArtistsScreen(
 
 @Composable
 private fun Progress() {
-    SkeletonLayout {
-        repeat(10) {
-            ListItem(
-                headlineContent = {
-                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                        SkeletonItem(modifier = Modifier.size(width = 130.dp, height = 16.dp))
-                        SkeletonItem(modifier = Modifier.size(width = 200.dp, height = 16.dp))
-                    }
-                },
-                leadingContent = {
-                    SkeletonItem(modifier = Modifier.size(48.dp))
-                }
-            )
+    SkeletonLayout(modifier = Modifier.fillMaxSize()) {
+        LazyVerticalGrid(
+            columns = if (isCompactWidth) {
+                GridCells.Fixed(2)
+            } else {
+                GridCells.Adaptive(AlbumItemDefaults.Width)
+            },
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            item(
+                span = { GridItemSpan(maxLineSpan) }
+            ) {
+                HeaderLayout(
+                    title = {
+                        Column(
+                            modifier = Modifier.singleHeader(),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            SkeletonItem(
+                                modifier = Modifier
+                                    .size(
+                                        400.dp,
+                                        32.dp
+                                    )
+                            )
+                            SkeletonItem(
+                                modifier = Modifier
+                                    .size(
+                                        200.dp,
+                                        32.dp
+                                    )
+                            )
+                        }
+                    },
+                    actions = {
+                        SkeletonItem(
+                            shape = CircleShape,
+                            modifier = Modifier.size(64.dp)
+                        )
+                        SkeletonItem(
+                            shape = CircleShape,
+                            modifier = Modifier.size(64.dp)
+                        )
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 24.dp)
+                )
+            }
+            repeat(10) {
+                item { ArtistSkeleton() }
+            }
         }
+    }
+}
+
+@Preview
+@Composable
+private fun FavoriteArtistsScreenProgressPreview() {
+    MaterialTheme {
+        FavoriteArtistsScreen(
+            state = StateUi(),
+            onPlayAll = {},
+            onPlayShuffled = {},
+            onRetry = {},
+            onRefresh = {},
+            onArtistClick = {},
+            onBackClick = {}
+        )
     }
 }
 

--- a/feature/artist/info/src/commonMain/kotlin/ru/stersh/youamp/feature/artist/info/ui/ArtistInfoScreen.kt
+++ b/feature/artist/info/src/commonMain/kotlin/ru/stersh/youamp/feature/artist/info/ui/ArtistInfoScreen.kt
@@ -1,10 +1,8 @@
 package ru.stersh.youamp.feature.artist.info.ui
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -19,12 +17,9 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.persistentListOf
@@ -33,18 +28,18 @@ import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 import ru.stersh.youamp.core.ui.AlbumItem
 import ru.stersh.youamp.core.ui.AlbumItemDefaults
+import ru.stersh.youamp.core.ui.AlbumSkeleton
+import ru.stersh.youamp.core.ui.ArtistItemDefaults
 import ru.stersh.youamp.core.ui.BackNavigationButton
 import ru.stersh.youamp.core.ui.CircleArtwork
 import ru.stersh.youamp.core.ui.ErrorLayout
 import ru.stersh.youamp.core.ui.FavoriteButton
 import ru.stersh.youamp.core.ui.HeaderLayout
-import ru.stersh.youamp.core.ui.LocalWindowSizeClass
 import ru.stersh.youamp.core.ui.PlayAllButton
 import ru.stersh.youamp.core.ui.PlayShuffledButton
 import ru.stersh.youamp.core.ui.SkeletonLayout
 import ru.stersh.youamp.core.ui.YouampPlayerTheme
 import ru.stersh.youamp.core.ui.isCompactWidth
-
 
 @Composable
 fun ArtistInfoScreen(
@@ -76,7 +71,7 @@ private fun ArtistInfoScreen(
     onFavoriteChange: (isFavorite: Boolean) -> Unit,
     onAlbumClick: (albumId: String) -> Unit,
     onRetry: () -> Unit,
-    onBackClick: () -> Unit,
+    onBackClick: () -> Unit
 ) {
     Scaffold(
         topBar = {
@@ -125,7 +120,11 @@ private fun Content(
     onAlbumClick: (albumId: String) -> Unit
 ) {
     LazyVerticalGrid(
-        columns = GridCells.Adaptive(160.dp),
+        columns = if (isCompactWidth) {
+            GridCells.Fixed(2)
+        } else {
+            GridCells.Adaptive(AlbumItemDefaults.Width)
+        },
         modifier = Modifier.padding(padding),
         contentPadding = PaddingValues(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
@@ -167,14 +166,13 @@ private fun Header(
     onFavoriteChange: (isFavorite: Boolean) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val windowWidthSizeClass = LocalWindowSizeClass.current.widthSizeClass
     HeaderLayout(
         image = {
             CircleArtwork(
                 artworkUrl = state.artworkUrl,
                 placeholder = Icons.Rounded.Person,
-                modifier = if (windowWidthSizeClass == WindowWidthSizeClass.Compact) {
-                    Modifier.size(160.dp)
+                modifier = if (isCompactWidth) {
+                    Modifier.size(ArtistItemDefaults.Width)
                 } else {
                     Modifier
                 }
@@ -204,82 +202,77 @@ private fun Header(
 
 @Composable
 private fun Progress(padding: PaddingValues) {
-    SkeletonLayout {
-        Column(modifier = Modifier.padding(padding)) {
-            HeaderLayout(
-                image = {
-                    SkeletonItem(
-                        modifier = if (LocalWindowSizeClass.current.widthSizeClass == WindowWidthSizeClass.Compact) {
-                            Modifier.size(160.dp)
-                        } else {
-                            Modifier.fillMaxWidth()
-                                .aspectRatio(1f)
-                        }.clip(CircleShape)
-                    )
-                },
-                title = {
-                    if (LocalWindowSizeClass.current.widthSizeClass == WindowWidthSizeClass.Compact) {
-                        Box(modifier = Modifier.fillMaxWidth()) {
-                            SkeletonItem(
-                                modifier = Modifier.size(280.dp, 32.dp)
-                                    .fillMaxWidth()
-                                    .align(Alignment.Center)
-                            )
-                        }
-                    } else {
-                        SkeletonItem(
-                            modifier = Modifier.size(300.dp, 48.dp)
-                        )
-                    }
-                },
-                subtitle = {
-                    if (LocalWindowSizeClass.current.widthSizeClass == WindowWidthSizeClass.Compact) {
-                        Box(modifier = Modifier.fillMaxWidth()) {
-                            SkeletonItem(
-                                modifier = Modifier.size(220.dp, 24.dp)
-                                    .fillMaxWidth()
-                                    .padding(top = 4.dp)
-                                    .align(Alignment.Center)
-                            )
-                        }
-                    } else {
-                        SkeletonItem(
-                            modifier = Modifier
-                                .size(220.dp, 24.dp)
-                                .padding(top = 4.dp)
-                        )
-                    }
-                },
-                actions = {
-                    repeat(2) {
-                        SkeletonItem(
-                            modifier = Modifier.size(64.dp)
-                                .clip(CircleShape)
-                        )
-                    }
-                }
-            )
-            LazyVerticalGrid(
-                columns = if (isCompactWidth) {
-                    GridCells.Fixed(2)
-                } else {
-                    GridCells.Adaptive(AlbumItemDefaults.Width)
-                },
-                contentPadding = PaddingValues(16.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-                userScrollEnabled = false
+    SkeletonLayout(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(padding)
+    ) {
+        LazyVerticalGrid(
+            columns = if (isCompactWidth) {
+                GridCells.Fixed(2)
+            } else {
+                GridCells.Adaptive(AlbumItemDefaults.Width)
+            },
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            item(
+                span = { GridItemSpan(maxLineSpan) }
             ) {
-                repeat(20) {
-                    item {
+                HeaderLayout(
+                    image = {
+                        SkeletonItem(
+                            shape = CircleShape,
+                            modifier = if (isCompactWidth) {
+                                Modifier.size(ArtistItemDefaults.Width)
+                            } else {
+                                Modifier
+                            }
+                        )
+                    },
+                    title = {
                         SkeletonItem(
                             modifier = Modifier
-                                .size(AlbumItemDefaults.Width, 220.dp)
+                                .size(
+                                    400.dp,
+                                    40.dp
+                                )
                         )
-                    }
-                }
+                    },
+                    actions = {
+                        repeat(3) {
+                            SkeletonItem(
+                                shape = CircleShape,
+                                modifier = Modifier.size(64.dp)
+                            )
+                        }
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 24.dp)
+                )
+            }
+            repeat(10) {
+                item { AlbumSkeleton(showArtist = false) }
             }
         }
+    }
+}
+
+@Preview
+@Composable
+private fun ArtistInfoScreenProgressPreview() {
+    YouampPlayerTheme {
+        ArtistInfoScreen(
+            state = ArtistInfoStateUi(),
+            onPlayAll = {},
+            onAlbumClick = {},
+            onPlayShuffled = {},
+            onFavoriteChange = {},
+            onRetry = {},
+            onBackClick = {}
+        )
     }
 }
 

--- a/feature/artist/list/src/commonMain/kotlin/ru/stersh/youamp/feature/artist/list/ui/ArtistsScreen.kt
+++ b/feature/artist/list/src/commonMain/kotlin/ru/stersh/youamp/feature/artist/list/ui/ArtistsScreen.kt
@@ -1,46 +1,34 @@
 package ru.stersh.youamp.feature.artist.list.ui
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LargeTopAppBar
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
+import ru.stersh.youamp.core.ui.ArtistItem
 import ru.stersh.youamp.core.ui.ArtistItemDefaults
+import ru.stersh.youamp.core.ui.ArtistSkeleton
 import ru.stersh.youamp.core.ui.BackNavigationButton
-import ru.stersh.youamp.core.ui.CircleArtwork
 import ru.stersh.youamp.core.ui.EmptyLayout
 import ru.stersh.youamp.core.ui.ErrorLayout
 import ru.stersh.youamp.core.ui.PullToRefresh
@@ -116,28 +104,42 @@ private fun ArtistsScreen(
                 }
 
                 else -> {
-                    LazyVerticalGrid(
-                        columns = if (isCompactWidth) {
-                            GridCells.Fixed(2)
-                        } else {
-                            GridCells.Adaptive(ArtistItemDefaults.Width)
-                        },
-                        contentPadding = PaddingValues(16.dp),
-                        horizontalArrangement = Arrangement.spacedBy(16.dp),
-                        verticalArrangement = Arrangement.spacedBy(16.dp),
-                        modifier = Modifier.fillMaxSize()
-                    ) {
-                        items(
-                            items = state.items
-                        ) { album ->
-                            ArtistItem(
-                                artist = album,
-                                onAlbumClick = onArtistClick
-                            )
-                        }
-                    }
+                    Content(
+                        items = state.items,
+                        onArtistClick = onArtistClick
+                    )
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun Content(
+    items: ImmutableList<ArtistUi>,
+    onArtistClick: (id: String) -> Unit
+) {
+    LazyVerticalGrid(
+        columns = if (isCompactWidth) {
+            GridCells.Fixed(2)
+        } else {
+            GridCells.Adaptive(ArtistItemDefaults.Width)
+        },
+        contentPadding = PaddingValues(16.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = Modifier.fillMaxSize()
+    ) {
+        items(
+            items = items
+        ) { artist ->
+            ArtistItem(
+                name = artist.name,
+                artworkUrl = artist.artworkUrl,
+                onClick = {
+                    onArtistClick.invoke(artist.id)
+                }
+            )
         }
     }
 }
@@ -153,58 +155,28 @@ private fun Progress() {
             },
             contentPadding = PaddingValues(16.dp),
             horizontalArrangement = Arrangement.spacedBy(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            userScrollEnabled = false
         ) {
             items(
                 items = (0..12).toList()
             ) {
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    SkeletonItem(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .aspectRatio(1f),
-                        shape = CircleShape
-                    )
-                    SkeletonItem(
-                        modifier = Modifier.size(width = 80.dp, height = 24.dp)
-                    )
-                }
+                ArtistSkeleton()
             }
         }
     }
 }
 
 @Composable
-private fun ArtistItem(
-    artist: ArtistUi,
-    onAlbumClick: (id: String) -> Unit
-) {
-    val selectableShape = remember { RoundedCornerShape(36.dp) }
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(selectableShape)
-            .clickable {
-                onAlbumClick(artist.id)
-            },
-    ) {
-        CircleArtwork(
-            artworkUrl = artist.artworkUrl,
-            placeholder = Icons.Rounded.Person,
-            modifier = Modifier.fillMaxWidth()
-        )
-        Text(
-            text = artist.name,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 8.dp, start = 12.dp, end = 12.dp),
-            textAlign = TextAlign.Center,
-            minLines = 2,
-            maxLines = 2,
-            style = MaterialTheme.typography.titleMedium
+@Preview
+private fun ArtistsScreenProgressPreview() {
+    YouampPlayerTheme {
+        ArtistsScreen(
+            state = ArtistsStateUi(),
+            onRetry = {},
+            onRefresh = {},
+            onArtistClick = {},
+            onBackClick = {}
         )
     }
 }

--- a/feature/library/src/commonMain/kotlin/ru/stersh/youamp/feature/library/ui/LibraryScreen.kt
+++ b/feature/library/src/commonMain/kotlin/ru/stersh/youamp/feature/library/ui/LibraryScreen.kt
@@ -3,46 +3,42 @@ package ru.stersh.youamp.feature.library.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidth
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.collections.immutable.persistentListOf
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
 import ru.stersh.youamp.core.ui.AlbumItem
 import ru.stersh.youamp.core.ui.AlbumItemDefaults
+import ru.stersh.youamp.core.ui.AlbumSkeleton
 import ru.stersh.youamp.core.ui.ArtistItem
+import ru.stersh.youamp.core.ui.ArtistSkeleton
 import ru.stersh.youamp.core.ui.ErrorLayout
 import ru.stersh.youamp.core.ui.LayoutStateUi
-import ru.stersh.youamp.core.ui.PlayButtonOutlined
 import ru.stersh.youamp.core.ui.PullToRefresh
 import ru.stersh.youamp.core.ui.Section
 import ru.stersh.youamp.core.ui.SectionScrollActions
+import ru.stersh.youamp.core.ui.SectionSkeleton
 import ru.stersh.youamp.core.ui.SkeletonLayout
 import ru.stersh.youamp.core.ui.StateLayout
 import ru.stersh.youamp.core.ui.YouampPlayerTheme
 import ru.stersh.youamp.core.ui.currentPlatform
-import ru.stersh.youamp.shared.queue.AudioSource
 import youamp.feature.library.generated.resources.Res
 import youamp.feature.library.generated.resources.albums_title
 import youamp.feature.library.generated.resources.artists_title
@@ -64,12 +60,10 @@ fun LibraryScreen(
         onAlbumsClick = onAlbumsClick,
         onArtistsClick = onArtistsClick,
         onRetry = viewModel::retry,
-        onRefresh = viewModel::refresh,
-        onPlayPauseAudioSource = viewModel::onPlayPauseAudioSource
+        onRefresh = viewModel::refresh
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun LibraryScreen(
     state: StateUi,
@@ -77,7 +71,6 @@ internal fun LibraryScreen(
     onArtistClick: (id: String) -> Unit,
     onAlbumsClick: () -> Unit,
     onArtistsClick: () -> Unit,
-    onPlayPauseAudioSource: (source: AudioSource) -> Unit,
     onRetry: () -> Unit,
     onRefresh: () -> Unit,
 ) {
@@ -103,7 +96,6 @@ internal fun LibraryScreen(
                     onArtistClick = onArtistClick,
                     onAlbumsClick = onAlbumsClick,
                     onArtistsClick = onArtistsClick,
-                    onPlayPauseAudioSource = onPlayPauseAudioSource
                 )
             },
             progress = {
@@ -126,7 +118,6 @@ private fun Content(
     onArtistClick: (id: String) -> Unit,
     onAlbumsClick: () -> Unit,
     onArtistsClick: () -> Unit,
-    onPlayPauseAudioSource: (source: AudioSource) -> Unit,
     modifier: Modifier = Modifier
 ) {
     if (data == null) {
@@ -162,14 +153,6 @@ private fun Content(
                                 title = it.title,
                                 artist = it.artist,
                                 artworkUrl = it.artworkUrl,
-                                playButton = {
-                                    PlayButtonOutlined(
-                                        isPlaying = it.isPlaying,
-                                        onClick = {
-                                            onPlayPauseAudioSource(AudioSource.Album(it.id))
-                                        }
-                                    )
-                                },
                                 onClick = {
                                     onAlbumClick(it.id)
                                 },
@@ -203,14 +186,6 @@ private fun Content(
                             ArtistItem(
                                 name = it.name,
                                 artworkUrl = it.artworkUrl,
-                                playButton = {
-                                    PlayButtonOutlined(
-                                        isPlaying = it.isPlaying,
-                                        onClick = {
-                                            onPlayPauseAudioSource(AudioSource.Artist(it.id))
-                                        }
-                                    )
-                                },
                                 onClick = {
                                     onArtistClick(it.id)
                                 },
@@ -229,66 +204,31 @@ private fun Progress(
     modifier: Modifier = Modifier
 ) {
     SkeletonLayout(modifier = modifier) {
-        Column(
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            modifier = Modifier.padding(
-                horizontal = 24.dp,
-                vertical = 16.dp
-            )
+        LazyColumn(
+            modifier = Modifier.padding(horizontal = 24.dp),
+            userScrollEnabled = false
         ) {
-            SkeletonItem(
-                modifier = Modifier.size(
-                    200.dp,
-                    48.dp
-                )
-            )
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                SkeletonItem(
-                    modifier = Modifier.size(
-                        160.dp,
-                        200.dp
-                    )
-                )
-                SkeletonItem(
-                    modifier = Modifier.size(
-                        160.dp,
-                        200.dp
-                    )
-                )
-                SkeletonItem(
-                    modifier = Modifier.size(
-                        160.dp,
-                        200.dp
-                    )
-                )
+            item { SectionSkeleton() }
+            item {
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    userScrollEnabled = false
+                ) {
+                    repeat(3) {
+                        item { AlbumSkeleton() }
+                    }
+                }
             }
-            SkeletonItem(
-                modifier = Modifier.size(
-                    200.dp,
-                    48.dp
-                )
-            )
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                SkeletonItem(
-                    modifier = Modifier
-                        .size(
-                            160.dp,
-                            160.dp
-                        )
-                        .clip(CircleShape)
-                )
-                SkeletonItem(
-                    modifier = Modifier
-                        .size(
-                            160.dp,
-                            160.dp
-                        )
-                        .clip(CircleShape)
-                )
+            item { SectionSkeleton() }
+            item {
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    userScrollEnabled = false
+                ) {
+                    repeat(3) {
+                        item { ArtistSkeleton() }
+                    }
+                }
             }
         }
     }
@@ -296,7 +236,7 @@ private fun Progress(
 
 @Composable
 @Preview
-private fun LibraryScreenPreview() {
+private fun LibraryScreenProgressPreview() {
     YouampPlayerTheme {
         LibraryScreen(
             state = StateUi(),
@@ -305,8 +245,50 @@ private fun LibraryScreenPreview() {
             onAlbumClick = {},
             onArtistClick = {},
             onArtistsClick = {},
-            onAlbumsClick = {},
-            onPlayPauseAudioSource = {}
+            onAlbumsClick = {}
+        )
+    }
+}
+
+@Composable
+@Preview
+private fun LibraryScreenPreview() {
+    YouampPlayerTheme {
+        LibraryScreen(
+            state = StateUi(
+                progress = false,
+                data = DataUi(
+                    albums = persistentListOf(
+                        AlbumUi(
+                            id = "Kashif",
+                            title = "Tremaine",
+                            artist = "Slipknot",
+                            artworkUrl = null,
+                            isPlaying = false,
+                        ),
+                    ),
+                    artists = persistentListOf(
+                        ArtistUi(
+                            id = "Soloman",
+                            name = "Eliana",
+                            artworkUrl = null,
+                            isPlaying = false,
+                        ),
+                        ArtistUi(
+                            id = "Tari",
+                            name = "Shamir",
+                            artworkUrl = null,
+                            isPlaying = false,
+                        ),
+                    )
+                )
+            ),
+            onRetry = {},
+            onRefresh = {},
+            onAlbumClick = {},
+            onArtistClick = {},
+            onArtistsClick = {},
+            onAlbumsClick = {}
         )
     }
 }

--- a/feature/personal/src/commonMain/kotlin/ru/stersh/youamp/feature/personal/Di.kt
+++ b/feature/personal/src/commonMain/kotlin/ru/stersh/youamp/feature/personal/Di.kt
@@ -7,6 +7,15 @@ import ru.stersh.youamp.feature.personal.domain.PersonalRepository
 import ru.stersh.youamp.feature.personal.ui.PersonalViewModel
 
 val personalModule = module {
-    single<PersonalRepository> { PersonalRepositoryImpl(get(), get(), get(), get(), get(), get()) }
-    viewModel { PersonalViewModel(get(), get(), get(), get()) }
+    single<PersonalRepository> {
+        PersonalRepositoryImpl(
+            get(),
+            get(),
+            get(),
+            get(),
+            get(),
+            get()
+        )
+    }
+    viewModel { PersonalViewModel(get()) }
 }

--- a/feature/personal/src/commonMain/kotlin/ru/stersh/youamp/feature/personal/ui/PersonalScreen.kt
+++ b/feature/personal/src/commonMain/kotlin/ru/stersh/youamp/feature/personal/ui/PersonalScreen.kt
@@ -6,16 +6,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidth
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -28,22 +25,26 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
 import ru.stersh.youamp.core.ui.AlbumItem
 import ru.stersh.youamp.core.ui.AlbumItemDefaults
+import ru.stersh.youamp.core.ui.AlbumSkeleton
 import ru.stersh.youamp.core.ui.ArtistItem
 import ru.stersh.youamp.core.ui.EmptyLayout
 import ru.stersh.youamp.core.ui.ErrorLayout
 import ru.stersh.youamp.core.ui.LayoutStateUi
-import ru.stersh.youamp.core.ui.PlayButton
-import ru.stersh.youamp.core.ui.PlayButtonOutlined
 import ru.stersh.youamp.core.ui.PlaylistItem
+import ru.stersh.youamp.core.ui.PlaylistItemDefaults
+import ru.stersh.youamp.core.ui.PlaylistSkeleton
 import ru.stersh.youamp.core.ui.PullToRefresh
 import ru.stersh.youamp.core.ui.Section
 import ru.stersh.youamp.core.ui.SectionScrollActions
+import ru.stersh.youamp.core.ui.SectionSkeleton
 import ru.stersh.youamp.core.ui.SkeletonLayout
+import ru.stersh.youamp.core.ui.SongCardChunkSkeleton
+import ru.stersh.youamp.core.ui.SongCardDefaults
 import ru.stersh.youamp.core.ui.SongCardItem
+import ru.stersh.youamp.core.ui.SongCardType
 import ru.stersh.youamp.core.ui.StateLayout
 import ru.stersh.youamp.core.ui.YouampPlayerTheme
 import ru.stersh.youamp.core.ui.currentPlatform
-import ru.stersh.youamp.shared.queue.AudioSource
 import youamp.feature.personal.generated.resources.Res
 import youamp.feature.personal.generated.resources.albums_title
 import youamp.feature.personal.generated.resources.artists_title
@@ -68,7 +69,6 @@ fun PersonalScreen(
         state = state,
         onRetry = viewModel::retry,
         onRefresh = viewModel::refresh,
-        onPlayPauseAudioSource = viewModel::onPlayPauseAudioSource,
         onSongClick = onSongClick,
         onAlbumClick = onAlbumClick,
         onArtistClick = onArtistClick,
@@ -80,13 +80,11 @@ fun PersonalScreen(
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun PersonalScreen(
     state: StateUi,
     onRetry: () -> Unit,
     onRefresh: () -> Unit,
-    onPlayPauseAudioSource: (source: AudioSource) -> Unit,
     onPlaylistsClick: () -> Unit,
     onFavoriteSongsClick: () -> Unit,
     onFavoriteAlbumsClick: () -> Unit,
@@ -103,14 +101,14 @@ private fun PersonalScreen(
         else -> LayoutStateUi.Content
     }
     PullToRefresh(
-        isRefreshing = state.refreshing, onRefresh = onRefresh
+        isRefreshing = state.refreshing,
+        onRefresh = onRefresh
     ) {
         StateLayout(
             state = layoutState,
             content = {
                 Content(
                     data = state.data,
-                    onPlayPauseAudioSource = onPlayPauseAudioSource,
                     onSongClick = onSongClick,
                     onAlbumClick = onAlbumClick,
                     onArtistClick = onArtistClick,
@@ -130,69 +128,60 @@ private fun PersonalScreen(
             empty = {
                 EmptyLayout()
             },
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier
+                .fillMaxSize()
                 .background(color = MaterialTheme.colorScheme.background)
         )
     }
 }
 
 @Composable
-private fun Progress(
-    modifier: Modifier = Modifier
-) {
+private fun Progress(modifier: Modifier = Modifier) {
     SkeletonLayout(modifier = modifier) {
-        Column(
-            verticalArrangement = Arrangement.spacedBy(16.dp), modifier = Modifier.padding(
-                horizontal = 24.dp, vertical = 16.dp
-            )
+        LazyColumn(
+            modifier = Modifier.padding(
+                horizontal = 24.dp
+            ),
+            userScrollEnabled = false
         ) {
-            SkeletonItem(
-                modifier = Modifier.size(
-                    200.dp, 48.dp
-                )
-            )
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                SkeletonItem(
-                    modifier = Modifier.size(
-                        160.dp, 200.dp
-                    )
-                )
-                SkeletonItem(
-                    modifier = Modifier.size(
-                        160.dp, 200.dp
-                    )
-                )
-                SkeletonItem(
-                    modifier = Modifier.size(
-                        160.dp, 200.dp
-                    )
-                )
+            item {
+                SectionSkeleton()
             }
-            SkeletonItem(
-                modifier = Modifier.size(
-                    200.dp, 48.dp
-                )
-            )
-            Column(
-                verticalArrangement = Arrangement.spacedBy(4.dp)
-            ) {
-                SkeletonItem(
-                    modifier = Modifier.size(
-                        336.dp, 64.dp
-                    )
-                )
-                SkeletonItem(
-                    modifier = Modifier.size(
-                        336.dp, 64.dp
-                    )
-                )
-                SkeletonItem(
-                    modifier = Modifier.size(
-                        336.dp, 64.dp
-                    )
-                )
+            item {
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    userScrollEnabled = false
+                ) {
+                    repeat(3) {
+                        item { PlaylistSkeleton() }
+                    }
+                }
+            }
+            item {
+                SectionSkeleton()
+            }
+            item {
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    userScrollEnabled = false
+                ) {
+                    repeat(2) {
+                        item { SongCardChunkSkeleton() }
+                    }
+                }
+            }
+            item {
+                SectionSkeleton()
+            }
+            item {
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    userScrollEnabled = false
+                ) {
+                    repeat(3) {
+                        item { AlbumSkeleton() }
+                    }
+                }
             }
         }
     }
@@ -211,7 +200,6 @@ private fun ProgressPreview() {
 @Composable
 private fun Content(
     data: PersonalDataUi?,
-    onPlayPauseAudioSource: (source: AudioSource) -> Unit,
     onPlaylistsClick: () -> Unit,
     onFavoriteSongsClick: () -> Unit,
     onFavoriteAlbumsClick: () -> Unit,
@@ -226,7 +214,10 @@ private fun Content(
         return
     }
     LazyColumn(
-        modifier = modifier.fillMaxSize().background(color = MaterialTheme.colorScheme.background),
+        modifier =
+            modifier
+                .fillMaxSize()
+                .background(color = MaterialTheme.colorScheme.background),
         contentPadding = PaddingValues(bottom = 24.dp)
     ) {
         if (data.playlists.isNotEmpty()) {
@@ -239,23 +230,21 @@ private fun Content(
                         if (!currentPlatform.mobile) {
                             SectionScrollActions(playlistsState)
                         }
-                    }) {
+                    }
+                ) {
                     LazyRow(
                         state = playlistsState,
                         contentPadding = PaddingValues(horizontal = 24.dp),
-                        horizontalArrangement = Arrangement.spacedBy(16.dp)
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
                     ) {
                         data.playlists.forEach {
                             item {
                                 PlaylistItem(
-                                    title = it.title, playButton = {
-                                        PlayButtonOutlined(
-                                            isPlaying = it.isPlaying, onClick = {
-                                                onPlayPauseAudioSource(AudioSource.Playlist(it.id))
-                                            })
-                                    }, onClick = {
+                                    title = it.title,
+                                    onClick = {
                                         onPlaylistClick(it.id)
-                                    }, modifier = Modifier.requiredWidth(160.dp)
+                                    },
+                                    modifier = Modifier.requiredWidth(PlaylistItemDefaults.Width)
                                 )
                             }
                         }
@@ -285,10 +274,10 @@ private fun Content(
                         data.songs.forEach { songChunk ->
                             item {
                                 Column(
-                                    verticalArrangement = Arrangement.spacedBy(4.dp),
-                                    modifier = Modifier.requiredWidth(336.dp)
+                                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                                    modifier = Modifier.requiredWidth(SongCardDefaults.Width),
                                 ) {
-                                    songChunk.forEach { item ->
+                                    songChunk.forEachIndexed { index, item ->
                                         SongCardItem(
                                             title = item.title,
                                             artist = item.artist,
@@ -296,15 +285,14 @@ private fun Content(
                                             onClick = {
                                                 onSongClick(item.id)
                                             },
-                                            playButton = {
-                                                PlayButton(
-                                                    isPlaying = item.isPlaying, onClick = {
-                                                        onPlayPauseAudioSource(
-                                                            AudioSource.Song(item.id)
-                                                        )
-                                                    })
-                                            },
-                                            modifier = Modifier.fillMaxWidth()
+                                            type =
+                                                when (index) {
+                                                    0 -> SongCardType.Top
+                                                    1 -> SongCardType.Center
+                                                    2 -> SongCardType.Bottom
+                                                    else -> SongCardType.Default
+                                                },
+                                            modifier = Modifier.fillMaxWidth(),
                                         )
                                     }
                                 }
@@ -338,12 +326,6 @@ private fun Content(
                                     title = it.title,
                                     artist = it.artist,
                                     artworkUrl = it.artworkUrl,
-                                    playButton = {
-                                        PlayButtonOutlined(
-                                            isPlaying = it.isPlaying, onClick = {
-                                                onPlayPauseAudioSource(AudioSource.Album(it.id))
-                                            })
-                                    },
                                     onClick = {
                                         onAlbumClick(it.id)
                                     },
@@ -353,9 +335,6 @@ private fun Content(
                         }
                     }
                 }
-            }
-            item {
-
             }
         }
         if (data.artists.isNotEmpty()) {
@@ -381,18 +360,9 @@ private fun Content(
                                 ArtistItem(
                                     name = it.name,
                                     artworkUrl = it.artworkUrl,
-                                    playButton = {
-                                        PlayButtonOutlined(
-                                            isPlaying = it.isPlaying, onClick = {
-                                                onPlayPauseAudioSource(
-                                                    AudioSource.Artist(it.id)
-                                                )
-                                            })
-                                    },
                                     onClick = {
                                         onArtistClick(it.id)
-                                    },
-                                    modifier = Modifier.requiredWidth(160.dp)
+                                    }
                                 )
                             }
                         }
@@ -413,15 +383,31 @@ private fun PersonalScreenPreview() {
             data = PersonalDataUi(
                 playlists = persistentListOf(
                     PlaylistUi(
-                        id = "Verna", title = "Sedric", artworkUrl = null, isPlaying = false
-                    ), PlaylistUi(
-                        id = "Verna", title = "Sedric", artworkUrl = null, isPlaying = false
-                    ), PlaylistUi(
-                        id = "Verna", title = "Sedric", artworkUrl = null, isPlaying = false
-                    ), PlaylistUi(
-                        id = "Verna", title = "Sedric", artworkUrl = null, isPlaying = true
-                    )
-                ), songs = persistentListOf(
+                        id = "Verna",
+                        title = "Sedric",
+                        artworkUrl = null,
+                        isPlaying = false
+                    ),
+                    PlaylistUi(
+                        id = "Verna",
+                        title = "Sedric",
+                        artworkUrl = null,
+                        isPlaying = false
+                    ),
+                    PlaylistUi(
+                        id = "Verna",
+                        title = "Sedric",
+                        artworkUrl = null,
+                        isPlaying = false
+                    ),
+                    PlaylistUi(
+                        id = "Verna",
+                        title = "Sedric",
+                        artworkUrl = null,
+                        isPlaying = true
+                    ),
+                ),
+                songs = persistentListOf(
                     persistentListOf(
                         SongUi(
                             id = "Indra",
@@ -429,41 +415,47 @@ private fun PersonalScreenPreview() {
                             artist = null,
                             artworkUrl = null,
                             isPlaying = false
-                        ), SongUi(
+                        ),
+                        SongUi(
                             id = "Raffaele",
                             title = "Brittny",
                             artist = null,
                             artworkUrl = null,
                             isPlaying = false
-                        ), SongUi(
+                        ),
+                        SongUi(
                             id = "Patsy",
                             title = "Brittiney",
                             artist = null,
                             artworkUrl = null,
                             isPlaying = false
                         )
-                    ), persistentListOf(
+                    ),
+                    persistentListOf(
                         SongUi(
                             id = "Julieta",
                             title = "Tykia",
                             artist = null,
                             artworkUrl = null,
                             isPlaying = false
-                        ), SongUi(
+                        ),
+                        SongUi(
                             id = "Kofi",
                             title = "Lyla",
                             artist = null,
                             artworkUrl = null,
                             isPlaying = false
-                        ), SongUi(
+                        ),
+                        SongUi(
                             id = "Kofi",
                             title = "Lyla",
                             artist = null,
                             artworkUrl = null,
-                            isPlaying = false
+                            isPlaying = false,
                         )
                     )
-                ), albums = persistentListOf(
+                ),
+                albums = persistentListOf(
                     AlbumUi(
                         id = "Kashif",
                         title = "Tremaine",
@@ -471,20 +463,27 @@ private fun PersonalScreenPreview() {
                         artworkUrl = null,
                         isPlaying = false
                     )
-                ), artists = persistentListOf(
+                ),
+                artists = persistentListOf(
                     ArtistUi(
-                        id = "Soloman", name = "Eliana", artworkUrl = null, isPlaying = false
-                    ), ArtistUi(
-                        id = "Tari", name = "Shamir", artworkUrl = null, isPlaying = false
+                        id = "Soloman",
+                        name = "Eliana",
+                        artworkUrl = null,
+                        isPlaying = false
+                    ),
+                    ArtistUi(
+                        id = "Tari",
+                        name = "Shamir",
+                        artworkUrl = null,
+                        isPlaying = false
                     )
                 )
-            ),
+            )
         )
         PersonalScreen(
             state = state,
             onRetry = {},
             onRefresh = {},
-            onPlayPauseAudioSource = {},
             onSongClick = {},
             onAlbumClick = {},
             onArtistClick = {},
@@ -492,6 +491,7 @@ private fun PersonalScreenPreview() {
             onPlaylistsClick = {},
             onFavoriteSongsClick = {},
             onFavoriteAlbumsClick = {},
-            onFavoriteArtistsClick = {})
+            onFavoriteArtistsClick = {}
+        )
     }
 }

--- a/feature/personal/src/commonMain/kotlin/ru/stersh/youamp/feature/personal/ui/PersonalViewModel.kt
+++ b/feature/personal/src/commonMain/kotlin/ru/stersh/youamp/feature/personal/ui/PersonalViewModel.kt
@@ -8,25 +8,15 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import ru.stersh.youamp.core.api.ApiProvider
-import ru.stersh.youamp.core.player.Player
 import ru.stersh.youamp.feature.personal.domain.PersonalRepository
-import ru.stersh.youamp.shared.queue.AudioSource
-import ru.stersh.youamp.shared.queue.PlayerQueueAudioSourceManager
-import ru.stersh.youamp.shared.queue.equals
 
 internal class PersonalViewModel(
-    private val personalRepository: PersonalRepository,
-    private val playerQueueAudioSourceManager: PlayerQueueAudioSourceManager,
-    private val player: Player,
-    private val apiProvider: ApiProvider
+    private val personalRepository: PersonalRepository
 ) : ViewModel() {
-
     private val _state = MutableStateFlow(StateUi())
     val state: StateFlow<StateUi>
         get() = _state
@@ -38,31 +28,32 @@ internal class PersonalViewModel(
     }
 
     private fun subscribeState() {
-        stateJob = viewModelScope.launch {
-            personalRepository
-                .getPersonal()
-                .map { it.toUi() }
-                .flowOn(Dispatchers.IO)
-                .catch {
-                    Logger.w(it) { "Error subscribing state" }
-                    _state.update {
-                        it.copy(
-                            progress = false,
-                            refreshing = false,
-                            error = true
-                        )
+        stateJob =
+            viewModelScope.launch {
+                personalRepository
+                    .getPersonal()
+                    .map { it.toUi() }
+                    .flowOn(Dispatchers.IO)
+                    .catch {
+                        Logger.w(it) { "Error subscribing state" }
+                        _state.update {
+                            it.copy(
+                                progress = false,
+                                refreshing = false,
+                                error = true,
+                            )
+                        }
                     }
-                }
-                .collect { personal ->
-                    _state.update {
-                        it.copy(
-                            progress = false,
-                            refreshing = false,
-                            data = personal
-                        )
+                    .collect { personal ->
+                        _state.update {
+                            it.copy(
+                                progress = false,
+                                refreshing = false,
+                                data = personal,
+                            )
+                        }
                     }
-                }
-        }
+            }
     }
 
     fun retry() {
@@ -83,30 +74,5 @@ internal class PersonalViewModel(
         }
         stateJob?.cancel()
         subscribeState()
-    }
-
-    fun onPlayPauseAudioSource(source: AudioSource) {
-        viewModelScope.launch {
-            val playingSource = playerQueueAudioSourceManager
-                .playingSource()
-                .first()
-            val serverId = apiProvider.requireApiId()
-            val isPlaying = player
-                .getIsPlaying()
-                .first()
-            val isSourcePlaying = playingSource?.equals(
-                serverId,
-                source
-            ) == true
-            if (isSourcePlaying && isPlaying) {
-                player.pause()
-                return@launch
-            }
-            if (isSourcePlaying) {
-                player.play()
-                return@launch
-            }
-            playerQueueAudioSourceManager.playSource(source)
-        }
     }
 }

--- a/feature/playlist/list/src/commonMain/kotlin/ru/stersh/youamp/feature/playlist/list/ui/PlaylistsScreen.kt
+++ b/feature/playlist/list/src/commonMain/kotlin/ru/stersh/youamp/feature/playlist/list/ui/PlaylistsScreen.kt
@@ -2,10 +2,7 @@ package ru.stersh.youamp.feature.playlist.list.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -13,12 +10,8 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.MusicNote
-import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LargeTopAppBar
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
@@ -26,18 +19,19 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
-import ru.stersh.youamp.core.ui.Artwork
 import ru.stersh.youamp.core.ui.BackNavigationButton
 import ru.stersh.youamp.core.ui.EmptyLayout
 import ru.stersh.youamp.core.ui.ErrorLayout
+import ru.stersh.youamp.core.ui.PlaylistItem
 import ru.stersh.youamp.core.ui.PlaylistItemDefaults
+import ru.stersh.youamp.core.ui.PlaylistSkeleton
 import ru.stersh.youamp.core.ui.PullToRefresh
 import ru.stersh.youamp.core.ui.SkeletonLayout
 import ru.stersh.youamp.core.ui.YouampPlayerTheme
@@ -111,29 +105,41 @@ private fun PlaylistsScreen(
                 }
 
                 else -> {
-                    LazyVerticalGrid(
-                        columns = if (isCompactWidth) {
-                            GridCells.Fixed(2)
-                        } else {
-                            GridCells.Adaptive(PlaylistItemDefaults.Width)
-                        },
-                        state = rememberLazyGridState(),
-                        contentPadding = PaddingValues(16.dp),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                        modifier = Modifier.fillMaxSize()
-                    ) {
-                        items(
-                            items = state.items
-                        ) { playlist ->
-                            PlaylistItem(
-                                playlist = playlist,
-                                onPlaylistClick = onPlaylistClick
-                            )
-                        }
-                    }
+                    Content(
+                        items = state.items,
+                        onPlaylistClick = onPlaylistClick
+                    )
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun Content(
+    items: ImmutableList<PlaylistUi>,
+    onPlaylistClick: (id: String) -> Unit
+) {
+    LazyVerticalGrid(
+        columns = if (isCompactWidth) {
+            GridCells.Fixed(2)
+        } else {
+            GridCells.Adaptive(PlaylistItemDefaults.Width)
+        },
+        state = rememberLazyGridState(),
+        contentPadding = PaddingValues(16.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = Modifier.fillMaxSize()
+    ) {
+        items(
+            items = items
+        ) { playlist ->
+            PlaylistItem(
+                title = playlist.name,
+                onClick = { onPlaylistClick.invoke(playlist.id) },
+                artworkUrl = playlist.artworkUrl
+            )
         }
     }
 }
@@ -148,48 +154,30 @@ private fun Progress() {
                 GridCells.Adaptive(PlaylistItemDefaults.Width)
             },
             contentPadding = PaddingValues(16.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            userScrollEnabled = false
         ) {
             items(
                 key = { it },
                 items = (0..20).toList()
             ) {
-                SkeletonItem(
-                    modifier = Modifier.height(220.dp)
-                )
+                PlaylistSkeleton()
             }
         }
     }
 }
 
 @Composable
-private fun PlaylistItem(
-    playlist: PlaylistUi,
-    onPlaylistClick: (id: String) -> Unit
-) {
-    ElevatedCard(
-        shape = MaterialTheme.shapes.large,
-        onClick = {
-            onPlaylistClick(playlist.id)
-        }
-    ) {
-        Artwork(
-            artworkUrl = playlist.artworkUrl,
-            placeholder = Icons.Rounded.MusicNote,
-            modifier = Modifier
-                .aspectRatio(1f)
-                .fillMaxWidth()
-        )
-        Text(
-            text = playlist.name,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(12.dp),
-            textAlign = TextAlign.Left,
-            minLines = 1,
-            maxLines = 1,
-            style = MaterialTheme.typography.labelLarge
+@Preview
+private fun PlaylistsScreenProgressPreview() {
+    YouampPlayerTheme {
+        PlaylistsScreen(
+            state = PlaylistsStateUi(),
+            onRetry = {},
+            onRefresh = {},
+            onPlaylistClick = {},
+            onBackClick = {}
         )
     }
 }

--- a/feature/song/favorites/src/commonMain/kotlin/ru/stersh/youamp/feature/song/favorites/ui/FavoriteSongsScreen.kt
+++ b/feature/song/favorites/src/commonMain/kotlin/ru/stersh/youamp/feature/song/favorites/ui/FavoriteSongsScreen.kt
@@ -1,36 +1,33 @@
 package ru.stersh.youamp.feature.song.favorites.ui
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.MusicNote
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.persistentListOf
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
-import ru.stersh.youamp.core.ui.Artwork
 import ru.stersh.youamp.core.ui.BackNavigationButton
 import ru.stersh.youamp.core.ui.EmptyLayout
 import ru.stersh.youamp.core.ui.ErrorLayout
@@ -39,6 +36,8 @@ import ru.stersh.youamp.core.ui.PlayAllButton
 import ru.stersh.youamp.core.ui.PlayShuffledButton
 import ru.stersh.youamp.core.ui.PullToRefresh
 import ru.stersh.youamp.core.ui.SkeletonLayout
+import ru.stersh.youamp.core.ui.SongItem
+import ru.stersh.youamp.core.ui.SongSkeleton
 import youamp.feature.song.favorites.generated.resources.Res
 import youamp.feature.song.favorites.generated.resources.favorite_songs_title
 
@@ -138,8 +137,10 @@ private fun FavoriteSongsScreen(
                                 contentType = { "song" },
                                 key = { "song_${it.id}" }
                             ) { song ->
-                                FavoriteSongItem(
-                                    song = song,
+                                SongItem(
+                                    title = song.title,
+                                    artist = song.artist,
+                                    artworkUrl = song.artworkUrl,
                                     onClick = { onSongClick(song.id) }
                                 )
                             }
@@ -153,54 +154,70 @@ private fun FavoriteSongsScreen(
 
 @Composable
 private fun Progress() {
-    SkeletonLayout {
-        repeat(10) {
-            ListItem(
-                headlineContent = {
-                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                        SkeletonItem(modifier = Modifier.size(width = 130.dp, height = 16.dp))
-                        SkeletonItem(modifier = Modifier.size(width = 200.dp, height = 16.dp))
-                    }
-                },
-                leadingContent = {
-                    SkeletonItem(modifier = Modifier.size(48.dp))
-                }
-            )
+    SkeletonLayout(modifier = Modifier.fillMaxSize()) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            item {
+                HeaderLayout(
+                    title = {
+                        Column(
+                            modifier = Modifier.singleHeader(),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            SkeletonItem(
+                                modifier = Modifier
+                                    .size(
+                                        400.dp,
+                                        32.dp
+                                    )
+                            )
+                            SkeletonItem(
+                                modifier = Modifier
+                                    .size(
+                                        200.dp,
+                                        32.dp
+                                    )
+                            )
+                        }
+                    },
+                    actions = {
+                        SkeletonItem(
+                            shape = CircleShape,
+                            modifier = Modifier.size(64.dp)
+                        )
+                        SkeletonItem(
+                            shape = CircleShape,
+                            modifier = Modifier.size(64.dp)
+                        )
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 24.dp)
+                )
+            }
+            repeat(10) {
+                item { SongSkeleton() }
+            }
         }
     }
 }
 
+@Preview
 @Composable
-private fun FavoriteSongItem(
-    song: SongUi,
-    onClick: () -> Unit
-) {
-    ListItem(
-        headlineContent = {
-            Text(
-                text = song.title,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-        },
-        supportingContent = {
-            song.artist?.let {
-                Text(
-                    text = it,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
-        },
-        leadingContent = {
-            Artwork(
-                artworkUrl = song.artworkUrl,
-                placeholder = Icons.Rounded.MusicNote,
-                modifier = Modifier.size(48.dp)
-            )
-        },
-        modifier = Modifier.clickable(onClick = onClick)
-    )
+private fun FavoriteSongsScreenProgressPreview() {
+    MaterialTheme {
+        FavoriteSongsScreen(
+            state = StateUi(),
+            onPlayAll = {},
+            onPlayShuffled = {},
+            onRetry = {},
+            onRefresh = {},
+            onSongClick = {},
+            onBackClick = {}
+        )
+    }
 }
 
 @Preview

--- a/feature/song/random/src/commonMain/kotlin/ru/stersh/youamp/feature/song/random/ui/RandomSongsScreen.kt
+++ b/feature/song/random/src/commonMain/kotlin/ru/stersh/youamp/feature/song/random/ui/RandomSongsScreen.kt
@@ -1,35 +1,32 @@
 package ru.stersh.youamp.feature.song.random.ui
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.MusicNote
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.persistentListOf
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
-import ru.stersh.youamp.core.ui.Artwork
 import ru.stersh.youamp.core.ui.BackNavigationButton
 import ru.stersh.youamp.core.ui.EmptyLayout
 import ru.stersh.youamp.core.ui.ErrorLayout
@@ -38,6 +35,8 @@ import ru.stersh.youamp.core.ui.PlayAllButton
 import ru.stersh.youamp.core.ui.PlayShuffledButton
 import ru.stersh.youamp.core.ui.PullToRefresh
 import ru.stersh.youamp.core.ui.SkeletonLayout
+import ru.stersh.youamp.core.ui.SongItem
+import ru.stersh.youamp.core.ui.SongSkeleton
 import youamp.feature.song.random.generated.resources.Res
 import youamp.feature.song.random.generated.resources.random_songs_title
 
@@ -155,8 +154,10 @@ private fun Content(
             contentType = { "song" },
             key = { "song_${it.id}" }
         ) { song ->
-            RandomSongItem(
-                song = song,
+            SongItem(
+                title = song.title,
+                artist = song.artist,
+                artworkUrl = song.artworkUrl,
                 onClick = { onSongClick(song.id) }
             )
         }
@@ -165,59 +166,75 @@ private fun Content(
 
 @Composable
 private fun Progress() {
-    SkeletonLayout {
-        repeat(10) {
-            ListItem(
-                headlineContent = {
-                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                        SkeletonItem(modifier = Modifier.size(width = 130.dp, height = 16.dp))
-                        SkeletonItem(modifier = Modifier.size(width = 200.dp, height = 16.dp))
-                    }
-                },
-                leadingContent = {
-                    SkeletonItem(modifier = Modifier.size(48.dp))
-                }
-            )
+    SkeletonLayout(modifier = Modifier.fillMaxSize()) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            item {
+                HeaderLayout(
+                    title = {
+                        Column(
+                            modifier = Modifier.singleHeader(),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            SkeletonItem(
+                                modifier = Modifier
+                                    .size(
+                                        400.dp,
+                                        32.dp
+                                    )
+                            )
+                            SkeletonItem(
+                                modifier = Modifier
+                                    .size(
+                                        200.dp,
+                                        32.dp
+                                    )
+                            )
+                        }
+                    },
+                    actions = {
+                        SkeletonItem(
+                            shape = CircleShape,
+                            modifier = Modifier.size(64.dp)
+                        )
+                        SkeletonItem(
+                            shape = CircleShape,
+                            modifier = Modifier.size(64.dp)
+                        )
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 24.dp)
+                )
+            }
+            repeat(10) {
+                item { SongSkeleton() }
+            }
         }
     }
 }
 
+@Preview
 @Composable
-private fun RandomSongItem(
-    song: SongUi,
-    onClick: () -> Unit
-) {
-    ListItem(
-        headlineContent = {
-            Text(
-                text = song.title,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-        },
-        supportingContent = {
-            song.artist?.let {
-                Text(
-                    text = it,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
-        },
-        leadingContent = {
-            Artwork(
-                artworkUrl = song.artworkUrl,
-                placeholder = Icons.Rounded.MusicNote,
-                modifier = Modifier.size(48.dp)
-            )
-        },
-        modifier = Modifier.clickable(onClick = onClick)
-    )
+private fun RandomSongsScreenProgressPreview() {
+    MaterialTheme {
+        RandomSongsScreen(
+            state = StateUi(),
+            onPlayAll = {},
+            onPlayShuffled = {},
+            onRetry = {},
+            onRefresh = {},
+            onSongClick = {},
+            onBackClick = {}
+        )
+    }
 }
 
 @Preview
 @Composable
-private fun FavoriteSongsScreenPreview() {
+private fun RandomSongsScreenPreview() {
     MaterialTheme {
         val songs = persistentListOf(
             SongUi(


### PR DESCRIPTION
1. From personal tab removed play buttons. It's looks ugly on artist card and I don't know what to do with that.
2. All contents redesigned, card under title removed, because card adds some padding to title, and long titles not visible well.
3. All skeletons redesigned with new content cards